### PR TITLE
Better error message when no name is supplied.

### DIFF
--- a/R/zap.R
+++ b/R/zap.R
@@ -215,7 +215,10 @@ wap_dfr <- function(...) wap(..., .ptype = data.frame())
 #' @export
 zap <- function(.tbl, ..., .ptype = list()) {
   names <- names(list(...))
-  assert_that(!is.null(names))
+  assert_that(
+    !is.null(names),
+    msg = "The formula supplied in `...` must be named."
+  )
   name <- names[[1L]]
   if (is_grouped_df(.tbl) && name %in% group_vars(.tbl)) {
     abort("cannot zap a grouping variable")

--- a/tests/testthat/test-zap.R
+++ b/tests/testthat/test-zap.R
@@ -14,7 +14,7 @@ test_that("zap() aborts when ... is not length 1", {
 })
 
 test_that("zap() formulas must be named", {
-  expect_error(zap(iris, ~Sepal.Length))
+  expect_error(zap(iris, ~Sepal.Length), "The formula supplied in `...` must be named.")
 })
 
 


### PR DESCRIPTION
Closes #1 

An alternative is to use `f_name()` on the function that the user supplies. This would probably require these checks that are currently in `wap()` to be duplicated in `zap()`

```r
assert_that(
    length(fs) == 1L,
    is_formula(fs[[1L]])
  )
```

so:

```r
zap <- function(.tbl, ..., .ptype = list()) {
  fs <- list(...)
  names <- names(fs)
  
  if (is.null(names)) {
    assert_that(
      length(fs) == 1L,
      is_formula(fs[[1L]])
    )
    name <- f_name(fs[[1]])
  }
  else {
    name <- names[[1L]]
  }
  
  if (is_grouped_df(.tbl) && name %in% group_vars(.tbl)) {
    abort("cannot zap a grouping variable")
  }
  
  .tbl[[name]] <- wap(.tbl, ..., .ptype = .ptype)
  .tbl
}
```

this is kind of like what `dplyr` does right?